### PR TITLE
ReplayFilter updates:

### DIFF
--- a/filters/ReplayFilter.py
+++ b/filters/ReplayFilter.py
@@ -828,7 +828,7 @@ class ReplayFilter(Filter):
         filepath.mkdir(exist_ok=True)
         filepath = filepath / filename
         with filepath.open(mode='w', encoding='utf-8') as f:
-            json.dump(self.data['final_classification'], f, ensure_ascii=False,
+            json.dump(self.data, f, ensure_ascii=False,
                       separators=(',', ':'))
         logging.info(f'Finished writing file: {filename}\n')
         self.file_end_write_time = time.time()


### PR DESCRIPTION
Filter the final classification packet so the final session data is available in case the user finishes and exits the session before all drivers have finished.
Added an is_session_started attribute to track the status of the current session. This prevents issues with multiple sessions starts being sent without a corresponding final classification packet. Ignore packets if a session hasn't started yet. This prevents issues with packets like final classification that should only be sent once, but get received twice by the filter.
Added the file version number to saved data files.